### PR TITLE
Update neuron-wallet-guide.md

### DIFF
--- a/docs/references/neuron-wallet-guide.md
+++ b/docs/references/neuron-wallet-guide.md
@@ -53,7 +53,10 @@ Click the most recent release (this must be **version 0.25.1 or later**）and th
 
 4. Copy and paste the commands below into the terminal / command line depending on whether you are using Mac or Windows:
 
-**please note:** the directory and folder name must match the commands below, if not, please modify the command script correspondingly.
+**please note:** 
+
+the directory and folder name must match the commands below, if not, please modify the command script correspondingly.
+the $ is not part of the command line, it's a placeholder for the file stored location on your computer.
 
 **Mac**
 


### PR DESCRIPTION
added a note "the $ is not part of the command line, it's a placeholder for the file stored location on your computer."