### PR TITLE
Update neuron-wallet-guide.md

### DIFF
--- a/docs/references/neuron-wallet-guide.md
+++ b/docs/references/neuron-wallet-guide.md
@@ -54,11 +54,12 @@ Click the most recent release (this must be **version 0.25.1 or later**）and th
 4. Copy and paste the commands below into the terminal / command line depending on whether you are using Mac or Windows:
 
 **please note:** the directory and folder name must match the commands below, if not, please modify the command script correspondingly.
+the $ is not part of the command line, it's a placeholder for the file stored location on your computer
 
 **Mac**
 
 ```
-$ cd ckb_v0.25.1_x86_64-apple-darwin
+cd /Users/(NAME)/Documents/ckb_v0.25.1_x86_64-apple-darwin 
 $./ckb --version
 $./ckb-cli --version
 ```
@@ -66,7 +67,7 @@ $./ckb-cli --version
 **Windows**
 
 ```
-$ cd ckb_v0.25.1_x86_64-pc-windows-msvc
+cd C:/ckb_v0.25.1_x86_64-pc-windows-msvc 
 $ ckb --version
 $ ckb-cli --versions
 ```


### PR DESCRIPTION
**please note:** the directory and folder name must match the commands below, if not, please modify the command script correspondingly.
the $ is not part of the command line, it's a placeholder for the file stored location on your computer

**Mac**

```
cd /Users/(NAME)/Documents/ckb_v0.25.1_x86_64-apple-darwin 
$./ckb --version
$./ckb-cli --version
```

**Windows**

```
cd C:/ckb_v0.25.1_x86_64-pc-windows-msvc 
$ ckb --version
$ ckb-cli --versions
```